### PR TITLE
Change visibility of GetDayChangeTime method from internal to public

### DIFF
--- a/Afk.ZoneInfo/TzTimeZone.cs
+++ b/Afk.ZoneInfo/TzTimeZone.cs
@@ -81,7 +81,7 @@ namespace Afk.ZoneInfo
         /// </summary>
         /// <param name="year">Année de recherche</param>
         /// <returns><see cref="DateTime">DateTime[]</see> des changements qui surviennent dans l'année spécifié.</returns>
-        internal DateTime[] GetDayChangeTime(int year)
+        public DateTime[] GetDayChangeTime(int year)
         {
             List<DateTime> dates = new List<DateTime>();
 


### PR DESCRIPTION
We are building a custom logic and it would be interesting for us to be able to get the change time list for a given year. 

I saw this method was not used anywhere so I just changed visibility from internal to public. 